### PR TITLE
Feature: user `error` instead of expections

### DIFF
--- a/src/representer/normalizations.nim
+++ b/src/representer/normalizations.nim
@@ -67,8 +67,9 @@ proc normalizeValue(value: NimNode, map: var IdentMap): NimNode =
   of nnkDotExpr: newDotExpr(value[0].normalizeValue(map), value[1].normalizeValue(map))
   of nnkPar: value[0].normalizeValue(map)
   else:
-    raise newException(ValueError, "dont know how to normalize " & value.repr & " with type: " &
-        $value.kind & " as a value")
+    error "dont know how to normalize " & value.repr & " with type: " &
+        $value.kind & " as a value"
+    newEmptyNode()
 
 
 proc normalizeIdentDef(def: NimNode, map: var IdentMap): NimNode =
@@ -123,7 +124,8 @@ proc normalizeImportExport(importStmt: NimNode, map: IdentMap): NimNode =
   of nnkImportStmt, nnkExportStmt:
     importStmt.kind.newTree(importStmt[0..^1].sortedByIt(if it.kind == nnkInfix: it.unpackInfix.left.strVal else: it.strVal)) # TODO: implemement normalizations of `import macros as m`
   else:
-    raise newException(ValueError, $importStmt & "is not a valid import or export stmt")
+    error $importStmt & "is not a valid import or export stmt"
+    newEmptyNode()
 
 proc normalizeStmtList*(code: NimNode, map: var IdentMap): NimNode =
   code.expectKind nnkStmtList


### PR DESCRIPTION
Use `macros.error` for errors regarding the representer logic instead
of exceptions which lead to more readable errors

https://github.com/exercism/nim-representer/runs/3225111135?check_suite_focus=true vs. https://github.com/exercism/nim-representer/runs/3239107225?check_suite_focus=true

```
/__w/nim-representer/nim-representer/src/representer/normalizations.nim(107, 5) Error: unhandled exception: dont know how to normalize ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"] with type: nnkBracket as a value [ValueError]
```
vs.
```
/__w/nim-representer/nim-representer/src/representer/normalizations.nim(107, 11) Error: dont know how to normalize ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"] with type: nnkBracket as a value
```
