### PR TITLE
Docs: Update to reflect current state of Exercism

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # nim-representer
-A tool to create a normalized representation of user-submitted code for v3 of [Exercism.io](https://exercism.io)
+A tool to create a normalized representation of user-submitted code for [Exercism](https://exercism.org)

--- a/nim_representer.nimble
+++ b/nim_representer.nimble
@@ -2,7 +2,7 @@
 
 version       = "0.1.0"
 author        = "Yoni Fihrer"
-description   = "A representer to normalize a submission on the `nim` track of exercism.io"
+description   = "A representer to normalize user-submitted code on the `nim` track of exercism.org"
 license       = "MIT"
 srcDir        = "src"
 bin           = @["representer"]

--- a/src/representer/normalizations.nim
+++ b/src/representer/normalizations.nim
@@ -1,4 +1,4 @@
-## Create an normalized AST of a submission on exercism.io to provide feedback
+## Create an normalized AST of a submission on exercism.org to provide feedback
 import algorithm, macros, strformat, sequtils, strutils, std/with
 import mapping
 


### PR DESCRIPTION
2 Changes were performed:
- Remove reference to v3 of Exercism as it is the current version.
- Change top-level domain from `.io` to `.org`

This is a follow up to #30