### PR TITLE
Feature: upgrade macro evaluation strategy to use `nimscripter`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
-      - uses: jiro4989/setup-nim-action@5efcb0ac6189962c61098fcbe9a0765c1d81467b
+      - uses: jiro4989/setup-nim-action@9a5a618a7cccbc7415b2a539f25c9681fafe0ddb
         with:
           nim-version: '1.6.6'
 
       - name: Cache nimble
         id: cache-nimble
-        uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09
+        uses: actions/cache@c3f1317a9e7b1ef106c153ac8c0f00fed3ddbc0d
         with:
           path: ~/.nimble
           key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}
@@ -36,13 +36,13 @@ jobs:
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
-      - uses: jiro4989/setup-nim-action@5efcb0ac6189962c61098fcbe9a0765c1d81467b
+      - uses: jiro4989/setup-nim-action@9a5a618a7cccbc7415b2a539f25c9681fafe0ddb
         with:
           nim-version: '1.6.6'
 
       - name: Cache nimble
         id: cache-nimble
-        uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09
+        uses: actions/cache@c3f1317a9e7b1ef106c153ac8c0f00fed3ddbc0d
         with:
           path: ~/.nimble
           key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   job1:
     name: Nim Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -31,7 +31,7 @@ jobs:
 
   job2:
     name: Smoke test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
         with:
           path: ~/.nimble
           key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}
-        if: runner.os != 'Windows'
 
       - name: Compile and run tests with `nimble test`
         run: "nimble test -Y"
@@ -48,7 +47,6 @@ jobs:
         with:
           path: ~/.nimble
           key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}
-        if: runner.os != 'Windows'
 
       - name: "Install nimble dependencies"
         run: "nimble install -y -d"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,8 @@ jobs:
           key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}
 
       - name: "Install nimble dependencies"
-        run: "nimble install -y -d"
         if: steps.cache-nimble.outputs.cache-hit != 'true'
+        run: "nimble install -y -d"
 
       - name: "Compile representer"
         run: "nimble c -d:release src/representer"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,7 @@ jobs:
           key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}
 
       - name: Compile and run tests with `nimble test`
-        run: "nimble test -Y"
-
+        run: "nimble test -y"
 
   job2:
     name: Smoke test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,18 @@ on:
 jobs:
   job1:
     name: Nim Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
-      - uses: jiro4989/setup-nim-action@v1
+      - uses: jiro4989/setup-nim-action@5efcb0ac6189962c61098fcbe9a0765c1d81467b
         with:
           nim-version: '1.6.6'
 
       - name: Cache nimble
         id: cache-nimble
-        uses: actions/cache@v1
+        uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09
         with:
           path: ~/.nimble
           key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}
@@ -33,18 +33,18 @@ jobs:
 
   job2:
     name: Smoke test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
-      - uses: jiro4989/setup-nim-action@v1
+      - uses: jiro4989/setup-nim-action@5efcb0ac6189962c61098fcbe9a0765c1d81467b
         with:
           nim-version: '1.6.6'
 
       - name: Cache nimble
         id: cache-nimble
-        uses: actions/cache@v1
+        uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09
         with:
           path: ~/.nimble
           key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,26 +10,57 @@ on:
 jobs:
   job1:
     name: Nim Tests
-    runs-on: ubuntu-18.04
-    container: nimlang/nim:1.2.4-ubuntu-regular@sha256:02a555518a05c354ccb2627940f6138fca1090d198e5a0eb60936c03a4875c69
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - uses: jiro4989/setup-nim-action@v1
+        with:
+          nim-version: '1.6.6'
+
+      - name: Cache nimble
+        id: cache-nimble
+        uses: actions/cache@v1
+        with:
+          path: ~/.nimble
+          key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}
+        if: runner.os != 'Windows'
 
       - name: Compile and run tests with `nimble test`
-        run: "nimble test"
+        run: "nimble test -Y"
+
+
   job2:
     name: Smoke test
-    runs-on: ubuntu-18.04
-    container: nimlang/nim:1.2.4-ubuntu-regular@sha256:02a555518a05c354ccb2627940f6138fca1090d198e5a0eb60936c03a4875c69
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - uses: jiro4989/setup-nim-action@v1
+        with:
+          nim-version: '1.6.6'
+
+      - name: Cache nimble
+        id: cache-nimble
+        uses: actions/cache@v1
+        with:
+          path: ~/.nimble
+          key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}
+        if: runner.os != 'Windows'
+
+      - name: "Install nimble dependencies"
+        run: "nimble install -y -d"
+        if: steps.cache-nimble.outputs.cache-hit != 'true'
+
+      - name: "Compile representer"
+        run: "nimble c -d:release src/representer"
 
       - name: "Make representation of `two-fer`"
         run: "bin/run.sh two-fer ${PWD}/tests/cases/example-two-fer/ ${PWD}/tests/cases/example-two-fer/"
 
       - name: "Check diffs"
         run: |
-          diff tests/cases/example-two-fer/mapping.json tests/cases/example-two-fer/expected/mapping.json
-          diff tests/cases/example-two-fer/representation.txt tests/cases/example-two-fer/expected/representation.txt
+          diff -y tests/cases/example-two-fer/mapping.json tests/cases/example-two-fer/expected/mapping.json
+          diff -y tests/cases/example-two-fer/representation.txt tests/cases/example-two-fer/expected/representation.txt

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -5,4 +5,5 @@ if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
     echo "slug, solution directory and output directory must be present"
     exit 1
 fi
-nim c -f --outdir:bin/ -d:slug="$1" -d:inDir="$2" -d:outDir="$3" src/representer
+
+bin/representer --slug="$1" --input-dir="$2" --output-dir="$3" --print

--- a/nim.cfg
+++ b/nim.cfg
@@ -1,3 +1,4 @@
+--path:"$nim"
 --verbosity=0
 --hint[Processing]:off
 --styleCheck:hint

--- a/nim_representer.nimble
+++ b/nim_representer.nimble
@@ -10,4 +10,4 @@ binDir        = "bin"
 
 # Dependencies
 
-requires "nim >= 1.0.0"
+requires "nim >= 1.0.0", "nimscripter == 1.0.14", "docopt == 0.6.8"

--- a/nim_representer.nimble
+++ b/nim_representer.nimble
@@ -10,4 +10,6 @@ binDir        = "bin"
 
 # Dependencies
 
-requires "nim >= 1.0.0", "nimscripter == 1.0.14", "docopt == 0.6.8"
+requires "nim >= 1.6.4"
+requires "nimscripter == 1.0.14"
+requires "docopt == 0.6.8"

--- a/nim_representer.nimble
+++ b/nim_representer.nimble
@@ -10,6 +10,6 @@ binDir        = "bin"
 
 # Dependencies
 
-requires "nim >= 1.6.4"
+requires "nim >= 1.6.6"
 requires "nimscripter == 1.0.14"
 requires "docopt == 0.6.8"

--- a/src/representer.nim
+++ b/src/representer.nim
@@ -19,7 +19,7 @@ Options:
                                         If omitted, output will be written to stdout.
 """
 
-proc getFileContents*(fileName: string): string = readFile fileName
+proc getFileContents(fileName: string): string = readFile fileName
 
 func underSlug(s: string): string = s.replace('-', '_')
 

--- a/src/representer.nim
+++ b/src/representer.nim
@@ -16,7 +16,7 @@ Options:
   -s <slug>, --slug=<slug>              The exercise slug.
   -i <in-dir>, --input-dir=<in-dir>     The directory of the submission and exercise files.
   -o <out-dir>, --output-dir=<out-dir>  The directory to output to.
-                                        This is optional and will then output to stdout.
+                                        If omitted, output will be written to stdout.
 """
 
 proc getFileContents*(fileName: string): string = readFile fileName

--- a/src/representer.nim
+++ b/src/representer.nim
@@ -28,7 +28,7 @@ proc main() =
   let intr = loadScript(NimScriptPath("src/representer/loader.nims"))
   let (tree, map) = intr.invoke(
     getTestableRepresentation,
-    getFileContents(&"""{args["--input-dir"]}/{($args["--slug"]).underSlug}.nim"""), true,
+    getFileContents($args["--input-dir"] / underslug($args["--slug"]) & ".nim"), true,
     returnType = SerializedRepresentation
   )
   if args["--output-dir"]:

--- a/src/representer.nim
+++ b/src/representer.nim
@@ -4,31 +4,31 @@ import representer/[mapping, types]
 import docopt
 
 const doc = """
-Exercism nim representation normalizer.
+  Exercism nim representation normalizer.
 
-Usage:
-  representer --slug=<slug> --input-dir=<in-dir> [--output-dir=<out-dir>] [--print]
+  Usage:
+    representer --slug=<slug> --input-dir=<in-dir> [--output-dir=<out-dir>] [--print]
 
-Options:
-  -h --help                             Show this help message.
-  -v, --version                         Display version.
-  -p, --print                           Print the results.
-  -s <slug>, --slug=<slug>              The exercise slug.
-  -i <in-dir>, --input-dir=<in-dir>     The directory of the submission and exercise files.
-  -o <out-dir>, --output-dir=<out-dir>  The directory to output to.
-                                        If omitted, output will be written to stdout.
-"""
+  Options:
+    -h --help                             Show this help message.
+    -v, --version                         Display version.
+    -p, --print                           Print the results.
+    -s <slug>, --slug=<slug>              The exercise slug.
+    -i <in-dir>, --input-dir=<in-dir>     The directory of the submission and exercise files.
+    -o <out-dir>, --output-dir=<out-dir>  The directory to output to.
+                                          If omitted, output will be written to stdout.
+  """.dedent
 
 proc getFileContents(fileName: string): string = readFile fileName
 
-func underSlug(s: string): string = s.replace('-', '_')
+func kebabToSnakeCase(s: string): string = s.replace('-', '_')
 
 proc main() =
   let args = docopt(doc)
   let intr = loadScript(NimScriptPath("src/representer/loader.nims"))
   let (tree, map) = intr.invoke(
     getTestableRepresentation,
-    getFileContents($args["--input-dir"] / underslug($args["--slug"]) & ".nim"), true,
+    getFileContents($args["--input-dir"] / kebabToSnakeCase($args["--slug"]) & ".nim"), true,
     returnType = SerializedRepresentation
   )
   if args["--output-dir"]:

--- a/src/representer/loader.nims
+++ b/src/representer/loader.nims
@@ -11,4 +11,3 @@ proc createRepresentation(contents: string): tuple[tree: NimNode, map: IdentMap]
 proc getTestableRepresentation*(contents: string, switch = false): SerializedRepresentation =
   let (tree, map) = createRepresentation(contents)
   result = (repr tree, $(if switch: %map.switchKeysValues else: %map))
-

--- a/src/representer/loader.nims
+++ b/src/representer/loader.nims
@@ -1,0 +1,14 @@
+import std/[json, macros]
+import mapping
+import normalizations
+import types
+
+proc createRepresentation*(file: string): tuple[tree: NimNode, map: IdentMap] =
+  var map: IdentMap
+  let code = parseStmt(file)
+  result = (tree: code.normalizeStmtList(map), map: map)
+
+proc getTestableRepresentation*(contents: string, switch = false): SerializedRepresentation =
+  let (tree, map) = createRepresentation(contents)
+  result = (repr tree, $(if switch: %map.switchKeysValues else: %map))
+

--- a/src/representer/loader.nims
+++ b/src/representer/loader.nims
@@ -1,7 +1,5 @@
 import std/[json, macros]
-import mapping
-import normalizations
-import types
+import "."/[mapping, normalizations, types]
 
 proc createRepresentation(contents: string): tuple[tree: NimNode, map: IdentMap] =
   var map: IdentMap

--- a/src/representer/loader.nims
+++ b/src/representer/loader.nims
@@ -3,9 +3,9 @@ import mapping
 import normalizations
 import types
 
-proc createRepresentation*(file: string): tuple[tree: NimNode, map: IdentMap] =
+proc createRepresentation(contents: string): tuple[tree: NimNode, map: IdentMap] =
   var map: IdentMap
-  let code = parseStmt(file)
+  let code = parseStmt(contents)
   result = (tree: code.normalizeStmtList(map), map: map)
 
 proc getTestableRepresentation*(contents: string, switch = false): SerializedRepresentation =

--- a/src/representer/normalizations.nim
+++ b/src/representer/normalizations.nim
@@ -2,6 +2,8 @@
 import algorithm, macros, strformat, sequtils, strutils, std/with
 import mapping
 
+{.experimental: "strictFuncs".}
+
 proc normalizeStmtList*(code: NimNode, map: var IdentMap): NimNode
 proc normalizeValue(value: NimNode, map: var IdentMap): NimNode
 
@@ -35,7 +37,7 @@ proc constructFmtStr(ast: NimNode, map: var IdentMap): string =
 proc normalizeCall(call: NimNode, map: var IdentMap): NimNode =
   result =
     if call.kind != nnkInfix and (call[0] == "fmt".ident or call[0] == "&".ident):
-      let fmtAst = getAst(fmt(call[1]))
+      let fmtAst = getAst(&(call[1]))
       let strToFmt = fmtAst[1..^2].mapIt(
         if $it[0][0] == "add":
           $it[2]

--- a/src/representer/normalizations.nim
+++ b/src/representer/normalizations.nim
@@ -2,8 +2,6 @@
 import algorithm, macros, strformat, sequtils, strutils, std/with
 import mapping
 
-{.experimental: "strictFuncs".}
-
 proc normalizeStmtList*(code: NimNode, map: var IdentMap): NimNode
 proc normalizeValue(value: NimNode, map: var IdentMap): NimNode
 

--- a/src/representer/normalizations.nim
+++ b/src/representer/normalizations.nim
@@ -1,6 +1,6 @@
 ## Create an normalized AST of a submission on exercism.org to provide feedback
-import algorithm, macros, strformat, sequtils, strutils, std/with
-import mapping
+import std/[algorithm, macros, strformat, sequtils, strutils, with]
+import "."/mapping
 
 proc normalizeStmtList*(code: NimNode, map: var IdentMap): NimNode
 proc normalizeValue(value: NimNode, map: var IdentMap): NimNode

--- a/src/representer/types.nim
+++ b/src/representer/types.nim
@@ -1,0 +1,14 @@
+import std/[sequtils, tables]
+import mapping
+
+type
+  Representation* = tuple
+    tree: string
+    map: IdentMap
+  SerializedRepresentation* = tuple
+    tree: string
+    map: string
+
+proc switchKeysValues*(map: IdentMap): OrderedTable[string, NormalizedIdent] =
+  toSeq(map.pairs).mapIt((it[1], it[0])).toOrderedTable
+

--- a/src/representer/types.nim
+++ b/src/representer/types.nim
@@ -13,4 +13,3 @@ proc switchKeysValues*(map: IdentMap): OrderedTable[string, NormalizedIdent] =
   result = collect(initOrderedTable):
     for key, val in map.pairs:
       {val: key}
-

--- a/src/representer/types.nim
+++ b/src/representer/types.nim
@@ -1,4 +1,4 @@
-import std/[sequtils, tables]
+import std/[sugar, tables]
 import mapping
 
 type
@@ -10,5 +10,7 @@ type
     map: string
 
 proc switchKeysValues*(map: IdentMap): OrderedTable[string, NormalizedIdent] =
-  toSeq(map.pairs).mapIt((it[1], it[0])).toOrderedTable
+  result = collect(initOrderedTable):
+    for key, val in map.pairs:
+      {val: key}
 

--- a/tests/tnormalizations.nim
+++ b/tests/tnormalizations.nim
@@ -17,95 +17,111 @@ suite "End to end":
       map.len == 1
 
   test "All features":
-    let (_, map) = getRepresentation"""type
-  Dollar = distinct int
+    let (_, map) = getRepresentation dedent """
 
-proc testProc(name: string = "", hello: int) =
+      type
+        Dollar = distinct int
 
-  discard name & $hello
+      proc testProc(name: string = "", hello: int) =
 
-let
-  x = 1
-  y = 2
-  z = y + x
+        discard name & $hello
 
-var
-  dollar: Dollar
+      let
+        x = 1
+        y = 2
+        z = y + x
 
-const
-  euro = 100.Dollar
+      var
+        dollar: Dollar
 
-testProc(name = $x, hello = y)
-testproC x
+      const
+        euro = 100.Dollar
 
-macro testMacro(code: untyped): untyped = discard
-template testTemplate(code: untyped): untyped = discard"""
+      testProc(name = $x, hello = y)
+      testproC x
+
+      macro testMacro(code: untyped): untyped = discard
+      template testTemplate(code: untyped): untyped = discard
+      """
 
     check map.len == 11
 
   test "No params, return type or statements":
     let (tree, _) = getRepresentation """proc helloWorld* = discard"""
 
-    check tree.strip == "proc placeholder_0*() =\n  discard".strip
+    check tree == "\nproc placeholder_0*() =\n  discard\n"
 
   test "All the things":
-    const expected = """import
-  algorithm, macros as m, strutils
+    const expected = dedent """
 
-let
-  placeholder_0 = 1
-  placeholder_1 = `$`(placeholder_0).strip.replace("\n", `$`(placeholder_0))
-proc placeholder_2*() =
-  echo("testing stdout")
+      import
+        algorithm, macros as m, strutils
 
-placeholder_2()
-proc placeholder_5*(placeholder_3: int; placeholder_4 = "seventeen"): string =
-  let placeholder_6 = `-`(placeholder_3, placeholder_0)
-  let placeholder_7 = `&`(placeholder_1, placeholder_4)
-  let placeholder_8 = `&`(`$`(placeholder_6), placeholder_7)
-  placeholder_8
+      let
+        placeholder_0 = 1
+        placeholder_1 = `$`(placeholder_0).strip.replace("\n", `$`(placeholder_0))
+      proc placeholder_2*() =
+        echo("testing stdout")
 
-echo(placeholder_0.placeholder_5)
-echo(placeholder_5(placeholder_3 = 1, placeholder_4 = "how old am I?"))"""
-    let (tree, _) = getRepresentation """import strutils, algorithm, macros as m
+      placeholder_2()
+      proc placeholder_5*(placeholder_3: int; placeholder_4 = "seventeen"): string =
+        let placeholder_6 = `-`(placeholder_3, placeholder_0)
+        let placeholder_7 = `&`(placeholder_1, placeholder_4)
+        let placeholder_8 = `&`(`$`(placeholder_6), placeholder_7)
+        placeholder_8
 
-let
-  x = 1
-  y = ($x).strip.replace("\n", $x)
+      echo(placeholder_0.placeholder_5)
+      echo(placeholder_5(placeholder_3 = 1, placeholder_4 = "how old am I?"))"""
 
-proc testStdout*() =
-  echo "testing stdout"
+    let (tree, _) = getRepresentation dedent """
 
-testStdout()
+      import strutils, algorithm, macros as m
 
-proc helloWorld*(name: int, age = "seventeen"): string =
-  let years = name - x
-  let fullName = y & age
-  let id = $yEARs & fuLLNamE
-  id
+      let
+        x = 1
+        y = ($x).strip.replace("\n", $x)
 
-echo x.helloWorld
+      proc testStdout*() =
+        echo "testing stdout"
 
-echo hELLOWORLD(name = 1, age = "how old am I?")"""
-    check tree.strip == expected.string
+      testStdout()
+
+      proc helloWorld*(name: int, age = "seventeen"): string =
+        let years = name - x
+        let fullName = y & age
+        let id = $yEARs & fuLLNamE
+        id
+
+      echo x.helloWorld
+
+      echo hELLOWORLD(name = 1, age = "how old am I?")"""
+
+    check tree == expected
 
 suite "Test specific functionality":
-  let expected = """import
-  strformat
+  const expected = dedent """
 
-proc placeholder_1*(placeholder_0 = "you"): string =
-  fmt"One for {placeholder_0}, one for me.""""
+    import
+      strformat
+
+    proc placeholder_1*(placeholder_0 = "you"): string =
+      fmt"One for {placeholder_0}, one for me."
+    """
+
   test "fmt strings":
-    let (tree, _) = getRepresentation """import strformat
+    let (tree, _) = getRepresentation dedent """
+      import strformat
 
-proc twoFer*(name = "you"): string =
-  fmt"One for {name}, one for me." """
+      proc twoFer*(name = "you"): string =
+        fmt"One for {name}, one for me." """
 
-    check tree.strip == expected.strip
+    check tree == expected
 
   test "fmt string with `&`":
-    let (tree, _) = getRepresentation """import strformat
+    let (tree, _) = getRepresentation dedent """
+      import strformat
 
-proc twoFer*(name = "you"): string =
-  &"One for {name}, one for me." """
-    check expected.strip == tree.strip
+      proc twoFer*(name = "you"): string =
+        &"One for {name}, one for me." """
+
+    check expected == tree

--- a/tests/tnormalizations.nim
+++ b/tests/tnormalizations.nim
@@ -124,4 +124,4 @@ suite "Test specific functionality":
       proc twoFer*(name = "you"): string =
         &"One for {name}, one for me." """
 
-    check expected == tree
+    check tree == expected


### PR DESCRIPTION
This upgrades the representer to use https://github.com/beef331/nimscripter.

This module is a branch between Nimscript (a subset of nim that runs in
the VM) and the compiled nim. It embeds an interpreter in to the
executable, and doesn't require a nim compiler to be in path. The
primary advantage is the the bridge is built-in, so there is no need for
recompiling to create a representation for  every exercise, as the
representer uses nim's macros which only function in the VM. Without
this, only the VM is used, but the executable has to be recompiled every
time.

This also greatly simplifies the testing process, as the representation
creation doesn't need to happen at compile to and injecting in. Rather,
it can happen at runtime with the VM bridge.

CI: update to use version 1.6.6 and refractor of the representer

https://github.com/jiro4989/setup-nim-action is used to install nim
using choosenim with the desired version.

Caching is utilized to not have to redownload the dependent packages
again and invalidates the cache when the nimble file changes. This is
the example used on the `setup-nim-action` repo `README.md`

Closes #9 as not relevant